### PR TITLE
Only output warning in verbose mode

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -2061,7 +2061,8 @@ def read_config(options, args, arglist, parser):
         # Second, parse the configuration
         for opt in config.options(pep8_section):
             if opt.replace('_', '-') not in parser.config_options:
-                print("  unknown option '%s' ignored" % opt)
+                if options.verbose:
+                    print("  unknown option '%s' ignored" % opt)
                 continue
             if options.verbose > 1:
                 print("  %s = %s" % (opt, config.get(pep8_section, opt)))


### PR DESCRIPTION
If a user has an invalid configuration option in their local pep8 config
file, a warning is emitted to STDOUT causing Code Climate to error the
build when it tries to parse the output as an issue.

For now only output this warning when pep8 is running in verbose mode.
Eventually this should likely output a warning item when using the Code
Climate formatter.

@codeclimate/review 
