### PR TITLE
Dockerfile/PEP8 update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
-FROM python:3.5
+FROM alpine:edge
+
+RUN apk --update add python3 && \
+  rm /var/cache/apk/*
 
 WORKDIR /usr/src/app
 
-RUN adduser -u 9000 app
+RUN adduser -u 9000 app -D
 COPY . /usr/src/app
 RUN chown -R app:app /usr/src/app
 

--- a/codeclimate-pep8
+++ b/codeclimate-pep8
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import json
 import os.path

--- a/pep8.py
+++ b/pep8.py
@@ -47,26 +47,29 @@ W warnings
 """
 from __future__ import with_statement
 
-import os
-import sys
-import re
-import time
 import inspect
-import keyword
-import tokenize
 import json
-from optparse import OptionParser
+import keyword
+import os
+import re
+import sys
+import time
+import tokenize
+import warnings
+
 from fnmatch import fnmatch
+from optparse import OptionParser
+
 try:
     from configparser import RawConfigParser
     from io import TextIOWrapper
 except ImportError:
     from ConfigParser import RawConfigParser
 
-__version__ = '1.6.3a0'
+__version__ = '2.2.1a0'
 
 DEFAULT_EXCLUDE = '.svn,CVS,.bzr,.hg,.git,__pycache__,.tox'
-DEFAULT_IGNORE = 'E121,E123,E126,E226,E24,E704'
+DEFAULT_IGNORE = 'E121,E123,E126,E226,E24,E704,W503'
 try:
     if sys.platform == 'win32':
         USER_CONFIG = os.path.expanduser(r'~\.pep8')
@@ -196,7 +199,7 @@ def trailing_blank_lines(physical_line, lines, line_number, total_lines):
             return len(physical_line), "W292 no newline at end of file"
 
 
-def maximum_line_length(physical_line, max_line_length, multiline):
+def maximum_line_length(physical_line, max_line_length, multiline, noqa):
     r"""Limit all lines to a maximum of 79 characters.
 
     There are still many devices around that are limited to 80 character
@@ -210,7 +213,7 @@ def maximum_line_length(physical_line, max_line_length, multiline):
     """
     line = physical_line.rstrip()
     length = len(line)
-    if length > max_line_length and not noqa(line):
+    if length > max_line_length and not noqa:
         # Special case for long URLs in multi-line docstrings or comments,
         # but still report the error when the 72 first chars are whitespaces.
         chunks = line.split()
@@ -235,7 +238,9 @@ def maximum_line_length(physical_line, max_line_length, multiline):
 
 
 def blank_lines(logical_line, blank_lines, indent_level, line_number,
-                blank_before, previous_logical, previous_indent_level):
+                blank_before, previous_logical,
+                previous_unindented_logical_line, previous_indent_level,
+                lines):
     r"""Separate top-level function and class definitions with two blank lines.
 
     Method definitions inside a class are separated by a single blank line.
@@ -247,13 +252,18 @@ def blank_lines(logical_line, blank_lines, indent_level, line_number,
     Use blank lines in functions, sparingly, to indicate logical sections.
 
     Okay: def a():\n    pass\n\n\ndef b():\n    pass
+    Okay: def a():\n    pass\n\n\nasync def b():\n    pass
     Okay: def a():\n    pass\n\n\n# Foo\n# Bar\n\ndef b():\n    pass
+    Okay: default = 1\nfoo = 1
+    Okay: classify = 1\nfoo = 1
 
     E301: class Foo:\n    b = 0\n    def bar():\n        pass
     E302: def a():\n    pass\n\ndef b(n):\n    pass
+    E302: def a():\n    pass\n\nasync def b(n):\n    pass
     E303: def a():\n    pass\n\n\n\ndef b(n):\n    pass
     E303: def a():\n\n\n\n    pass
     E304: @decorator\n\ndef a():\n    pass
+    E305: def a():\n    pass\na()
     """
     if line_number < 3 and not previous_logical:
         return  # Don't expect blank lines before the first line
@@ -262,13 +272,30 @@ def blank_lines(logical_line, blank_lines, indent_level, line_number,
             yield 0, "E304 blank lines found after function decorator"
     elif blank_lines > 2 or (indent_level and blank_lines == 2):
         yield 0, "E303 too many blank lines (%d)" % blank_lines
-    elif logical_line.startswith(('def ', 'class ', '@')):
+    elif logical_line.startswith(('def ', 'async def', 'class ', '@')):
         if indent_level:
             if not (blank_before or previous_indent_level < indent_level or
                     DOCSTRING_REGEX.match(previous_logical)):
-                yield 0, "E301 expected 1 blank line, found 0"
+                ancestor_level = indent_level
+                nested = False
+                # Search backwards for a def ancestor or tree root (top level).
+                for line in lines[line_number - 2::-1]:
+                    if line.strip() and expand_indent(line) < ancestor_level:
+                        ancestor_level = expand_indent(line)
+                        nested = line.lstrip().startswith('def ')
+                        if nested or ancestor_level == 0:
+                            break
+                if nested:
+                    yield 0, "E306 expected 1 blank line before a " \
+                        "nested definition, found 0"
+                else:
+                    yield 0, "E301 expected 1 blank line, found 0"
         elif blank_before != 2:
             yield 0, "E302 expected 2 blank lines, found %d" % blank_before
+    elif (logical_line and not indent_level and blank_before != 2 and
+          previous_unindented_logical_line.startswith(('def ', 'class '))):
+        yield 0, "E305 expected 2 blank lines after " \
+            "class or function definition, found %d" % blank_before
 
 
 def extraneous_whitespace(logical_line):
@@ -324,6 +351,23 @@ def whitespace_around_keywords(logical_line):
             yield match.start(2), "E273 tab after keyword"
         elif len(after) > 1:
             yield match.start(2), "E271 multiple spaces after keyword"
+
+
+def missing_whitespace_after_import_keyword(logical_line):
+    r"""Multiple imports in form from x import (a, b, c) should have space
+    between import statement and parenthesised name list.
+
+    Okay: from foo import (bar, baz)
+    E275: from foo import(bar, baz)
+    E275: from importable.module import(bar, baz)
+    """
+    line = logical_line
+    indicator = ' import('
+    if line.startswith('from '):
+        found = line.find(indicator)
+        if -1 < found:
+            pos = found + len(indicator) - 1
+            yield pos, "E275 missing whitespace after keyword"
 
 
 def missing_whitespace(logical_line):
@@ -566,7 +610,7 @@ def continued_indentation(logical_line, tokens, indent_level, hang_closing,
                         break
             assert len(indent) == depth + 1
             if start[1] not in indent_chances:
-                # allow to line up tokens
+                # allow lining up tokens
                 indent_chances[start[1]] = text
 
         last_token_multiline = (start[0] != end[0])
@@ -760,6 +804,7 @@ def whitespace_around_named_parameter_equals(logical_line, tokens):
     Okay: boolean(a <= b)
     Okay: boolean(a >= b)
     Okay: def foo(arg: int = 42):
+    Okay: async def foo(arg: int = 42):
 
     E251: def complex(real, imag = 0.0):
     E251: return magic(r = real, i = imag)
@@ -768,7 +813,7 @@ def whitespace_around_named_parameter_equals(logical_line, tokens):
     no_space = False
     prev_end = None
     annotated_func_arg = False
-    in_def = logical_line.startswith('def')
+    in_def = logical_line.startswith(('def', 'async def'))
     message = "E251 unexpected spaces around keyword / parameter equals"
     for token_type, text, start, end, line in tokens:
         if token_type == tokenize.NL:
@@ -778,9 +823,9 @@ def whitespace_around_named_parameter_equals(logical_line, tokens):
             if start != prev_end:
                 yield (prev_end, message)
         if token_type == tokenize.OP:
-            if text == '(':
+            if text in '([':
                 parens += 1
-            elif text == ')':
+            elif text in ')]':
                 parens -= 1
             elif in_def and text == ':' and parens == 1:
                 annotated_func_arg = True
@@ -838,7 +883,7 @@ def whitespace_before_comment(logical_line, tokens):
 
 
 def imports_on_separate_lines(logical_line):
-    r"""Imports should usually be on separate lines.
+    r"""Place imports on separate lines.
 
     Okay: import os\nimport sys
     E401: import sys, os
@@ -858,8 +903,10 @@ def imports_on_separate_lines(logical_line):
 
 def module_imports_on_top_of_file(
         logical_line, indent_level, checker_state, noqa):
-    r"""Imports are always put at the top of the file, just after any module
-    comments and docstrings, and before module globals and constants.
+    r"""Place imports at the top of the file.
+
+    Always put imports at the top of the file, just after any module comments
+    and docstrings, and before module globals and constants.
 
     Okay: import os
     Okay: # this is a comment\nimport os
@@ -937,22 +984,25 @@ def compound_statements(logical_line):
     line = logical_line
     last_char = len(line) - 1
     found = line.find(':')
+    prev_found = 0
+    counts = dict((char, 0) for char in '{}[]()')
     while -1 < found < last_char:
-        before = line[:found]
-        if ((before.count('{') <= before.count('}') and   # {'a': 1} (dict)
-             before.count('[') <= before.count(']') and   # [1:2] (slice)
-             before.count('(') <= before.count(')'))):    # (annotation)
-            lambda_kw = LAMBDA_REGEX.search(before)
+        update_counts(line[prev_found:found], counts)
+        if ((counts['{'] <= counts['}'] and   # {'a': 1} (dict)
+             counts['['] <= counts[']'] and   # [1:2] (slice)
+             counts['('] <= counts[')'])):    # (annotation)
+            lambda_kw = LAMBDA_REGEX.search(line, 0, found)
             if lambda_kw:
                 before = line[:lambda_kw.start()].rstrip()
                 if before[-1:] == '=' and isidentifier(before[:-1].strip()):
                     yield 0, ("E731 do not assign a lambda expression, use a "
                               "def")
                 break
-            if before.startswith('def '):
+            if line.startswith('def '):
                 yield 0, "E704 multiple statements on one line (def)"
             else:
                 yield found, "E701 multiple statements on one line (colon)"
+        prev_found = found
         found = line.find(':', found + 1)
     found = line.find(';')
     while -1 < found:
@@ -1018,16 +1068,22 @@ def break_around_binary_operator(logical_line, tokens):
     Okay: x = '''\n''' + ''
     Okay: foo(x,\n    -y)
     Okay: foo(x,  # comment\n    -y)
+    Okay: var = (1 &\n       ~2)
+    Okay: var = (1 /\n       -2)
+    Okay: var = (1 +\n       -1 +\n       -2)
     """
     def is_binary_operator(token_type, text):
         # The % character is strictly speaking a binary operator, but the
         # common usage seems to be to put it next to the format parameters,
         # after a line break.
         return ((token_type == tokenize.OP or text in ['and', 'or']) and
-                text not in "()[]{},:.;@=%")
+                text not in "()[]{},:.;@=%~")
 
     line_break = False
     unary_context = True
+    # Previous non-newline token types and text
+    previous_token_type = None
+    previous_text = None
     for token_type, text, start, end, line in tokens:
         if token_type == tokenize.COMMENT:
             continue
@@ -1035,10 +1091,14 @@ def break_around_binary_operator(logical_line, tokens):
             line_break = True
         else:
             if (is_binary_operator(token_type, text) and line_break and
-                    not unary_context):
+                    not unary_context and
+                    not is_binary_operator(previous_token_type,
+                                           previous_text)):
                 yield start, "W503 line break before binary operator"
             unary_context = text in '([{,;'
             line_break = False
+            previous_token_type = token_type
+            previous_text = text
 
 
 def comparison_to_singleton(logical_line, noqa):
@@ -1119,6 +1179,58 @@ def comparison_type(logical_line, noqa):
         yield match.start(), "E721 do not compare types, use 'isinstance()'"
 
 
+def ambiguous_identifier(logical_line, tokens):
+    r"""Never use the characters 'l', 'O', or 'I' as variable names.
+
+    In some fonts, these characters are indistinguishable from the numerals
+    one and zero. When tempted to use 'l', use 'L' instead.
+
+    Okay: L = 0
+    Okay: o = 123
+    Okay: i = 42
+    E741: l = 0
+    E741: O = 123
+    E741: I = 42
+
+    Variables can be bound in several other contexts, including class and
+    function definitions, 'global' and 'nonlocal' statements, exception
+    handlers, and 'with' statements.
+
+    Okay: except AttributeError as o:
+    Okay: with lock as L:
+    E741: except AttributeError as O:
+    E741: with lock as l:
+    E741: global I
+    E741: nonlocal l
+    E742: class I(object):
+    E743: def l(x):
+    """
+    idents_to_avoid = ('l', 'O', 'I')
+    prev_type, prev_text, prev_start, prev_end, __ = tokens[0]
+    for token_type, text, start, end, line in tokens[1:]:
+        ident = pos = None
+        # identifiers on the lhs of an assignment operator
+        if token_type == tokenize.OP and '=' in text:
+            if prev_text in idents_to_avoid:
+                ident = prev_text
+                pos = prev_start
+        # identifiers bound to a value with 'as', 'global', or 'nonlocal'
+        if prev_text in ('as', 'global', 'nonlocal'):
+            if text in idents_to_avoid:
+                ident = text
+                pos = start
+        if prev_text == 'class':
+            if text in idents_to_avoid:
+                yield start, "E742 ambiguous class definition '%s'" % text
+        if prev_text == 'def':
+            if text in idents_to_avoid:
+                yield start, "E743 ambiguous function definition '%s'" % text
+        if ident:
+            yield pos, "E741 ambiguous variable name '%s'" % ident
+        prev_text = text
+        prev_start = start
+
+
 def python_3000_has_key(logical_line, noqa):
     r"""The {}.has_key() method is removed in Python 3: use the 'in' operator.
 
@@ -1157,7 +1269,7 @@ def python_3000_not_equal(logical_line):
 
 
 def python_3000_backticks(logical_line):
-    r"""Backticks are removed in Python 3: use repr() instead.
+    r"""Use repr() instead of backticks in Python 3.
 
     Okay: val = repr(1 + 2)
     W604: val = `1 + 2`
@@ -1188,7 +1300,7 @@ else:
             with open(filename, 'rb') as f:
                 (coding, lines) = tokenize.detect_encoding(f.readline)
                 f = TextIOWrapper(f, coding, line_buffering=True)
-                return [l.decode(coding) for l in lines] + f.readlines()
+                return [line.decode(coding) for line in lines] + f.readlines()
         except (LookupError, SyntaxError, UnicodeError):
             # Fall back if file encoding is improperly declared
             with open(filename, encoding='latin-1') as f:
@@ -1196,7 +1308,9 @@ else:
     isidentifier = str.isidentifier
 
     def stdin_get_value():
+        """Read the value from stdin."""
         return TextIOWrapper(sys.stdin.buffer, errors='ignore').read()
+
 noqa = re.compile(r'# no(?:qa|pep8)\b', re.I).search
 
 
@@ -1300,8 +1414,18 @@ def filename_match(filename, patterns, default=True):
     return any(fnmatch(filename, pattern) for pattern in patterns)
 
 
+def update_counts(s, counts):
+    r"""Adds one to the counts of each appearance of characters in s,
+        for characters in counts"""
+    for char in s:
+        if char in counts:
+            counts[char] += 1
+
+
 def _is_eol_token(token):
     return token[0] in NEWLINE or token[4][token[3][1]:].lstrip() == '\\\n'
+
+
 if COMMENT_WITH_NL:
     def _is_eol_token(token, _eol_token=_is_eol_token):
         return _eol_token(token) or (token[0] == tokenize.COMMENT and
@@ -1351,6 +1475,8 @@ def init_checks_registry():
     mod = inspect.getmodule(register_check)
     for (name, function) in inspect.getmembers(mod, inspect.isfunction):
         register_check(function)
+
+
 init_checks_registry()
 
 
@@ -1398,6 +1524,7 @@ class Checker(object):
                     self.lines[0] = self.lines[0][3:]
         self.report = report or options.report
         self.report_error = self.report.error
+        self.noqa = False
 
     def report_invalid_syntax(self):
         """Check if the syntax is valid."""
@@ -1430,7 +1557,7 @@ class Checker(object):
         return check(*arguments)
 
     def init_checker_state(self, name, argument_names):
-        """ Prepares a custom state for the specific checker plugin."""
+        """Prepare custom state for the specific checker plugin."""
         if 'checker_state' in argument_names:
             self.checker_state = self._checker_states.setdefault(name, {})
 
@@ -1508,6 +1635,8 @@ class Checker(object):
         if self.logical_line:
             self.previous_indent_level = self.indent_level
             self.previous_logical = self.logical_line
+            if not self.indent_level:
+                self.previous_unindented_logical_line = self.logical_line
         self.blank_lines = 0
         self.tokens = []
 
@@ -1532,6 +1661,7 @@ class Checker(object):
             for token in tokengen:
                 if token[2][0] > self.total_lines:
                     return
+                self.noqa = token[4] and noqa(token[4])
                 self.maybe_check_physical(token)
                 yield token
         except (SyntaxError, tokenize.TokenError):
@@ -1577,6 +1707,7 @@ class Checker(object):
         self.indent_char = None
         self.indent_level = self.previous_indent_level = 0
         self.previous_logical = ''
+        self.previous_unindented_logical_line = ''
         self.tokens = []
         self.blank_lines = self.blank_before = 0
         parens = 0
@@ -1712,6 +1843,7 @@ class BaseReport(object):
 
 class FileReport(BaseReport):
     """Collect the results of the checks and print only the filenames."""
+
     print_filename = True
 
 
@@ -1956,6 +2088,7 @@ class StyleGuide(object):
 
 
 def get_parser(prog='pep8', version=__version__):
+    """Create the parser for the program."""
     parser = OptionParser(prog=prog, version=version,
                           usage="%prog [options] input ...")
     parser.config_options = [
@@ -2019,7 +2152,7 @@ def get_parser(prog='pep8', version=__version__):
 
 
 def read_config(options, args, arglist, parser):
-    """Read and parse configurations
+    """Read and parse configurations.
 
     If a config file is specified on the command line with the "--config"
     option, then only it is used for configuration.
@@ -2072,13 +2205,12 @@ def read_config(options, args, arglist, parser):
             opt_type = option_list[normalized_opt]
             if opt_type in ('int', 'count'):
                 value = config.getint(pep8_section, opt)
-            elif opt_type == 'string':
+            elif opt_type in ('store_true', 'store_false'):
+                value = config.getboolean(pep8_section, opt)
+            else:
                 value = config.get(pep8_section, opt)
                 if normalized_opt == 'exclude':
                     value = normalize_paths(value, local_dir)
-            else:
-                assert opt_type in ('store_true', 'store_false')
-                value = config.getboolean(pep8_section, opt)
             setattr(new_options, normalized_opt, value)
 
         # Third, overwrite with the command-line options
@@ -2166,14 +2298,14 @@ def _main():
     except AttributeError:
         pass    # not supported on Windows
 
-    pep8style = StyleGuide(parse_argv=True)
-    options = pep8style.options
+    style_guide = StyleGuide(parse_argv=True)
+    options = style_guide.options
 
     if options.doctest or options.testsuite:
         from testsuite.support import run_tests
-        report = run_tests(pep8style)
+        report = run_tests(style_guide)
     else:
-        report = pep8style.check_files()
+        report = style_guide.check_files()
 
     if options.statistics:
         report.print_statistics()
@@ -2187,7 +2319,8 @@ def _main():
     if report.total_errors:
         if options.count:
             sys.stderr.write(str(report.total_errors) + '\n')
-            sys.exit(1)
+        sys.exit(1)
+
 
 if __name__ == '__main__':
     _main()

--- a/pep8.py
+++ b/pep8.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # pep8.py - Check Python source code formatting, according to PEP 8
 # Copyright (C) 2006-2009 Johann C. Rocholl <johann@rocholl.net>
 # Copyright (C) 2009-2014 Florent Xicluna <florent.xicluna@gmail.com>


### PR DESCRIPTION
# Dockerfile changes

* Base image switched to Alpine. The new image is almost 11x smaller (63.97 MiB vs 693 MiB).

# PEP8 Changelog

2.2.0 (2016-11-14)
------------------

Bugs:

* Fixed E305 regression caused by PyCQA/pycodestyle#400;
  PyCQA/pycodestyle#593

2.1.0 (2016-11-04)
------------------

Changes:

* Report E302 for blank lines before an "async def";
  PyCQA/pycodestyle#556
* Update our list of tested and supported Python versions which are 2.6,
  2.7, 3.2, 3.3, 3.4 and 3.5 as well as the nightly Python build and
  PyPy.
* Report E742 and E743 for functions and classes badly named 'l', 'O',
  or 'I'.
* Report E741 on 'global' and 'nonlocal' statements, as well as
  prohibited single-letter variables.
* Deprecated use of `[pep8]` section name in favor of `[pycodestyle]`;
  PyCQA/pycodestyle#591

Bugs:

* Fix opt_type AssertionError when using Flake8 2.6.2 and pycodestyle;
  PyCQA/pycodestyle#561
* Require two blank lines after toplevel def, class;
  PyCQA/pycodestyle#536
* Remove accidentally quadratic computation based on the number of
  colons. This will make pycodestyle faster in some cases;
  PyCQA/pycodestyle#314

2.0.0 (2016-05-31)

Changes:

* Added tox test support for Python 3.5 and pypy3
* Added check E275 for whitespace on `from ... import ...` lines;
  PyCQA/pycodestyle#489 / PyCQA/pycodestyle#491
* Added W503 to the list of codes ignored by default ignore list;
  PyCQA/pycodestyle#498
* Removed use of project level `.pep8` configuration file;
  PyCQA/pycodestyle#364

Bugs:

* Fixed bug with treating `~` operator as binary; PyCQA/pycodestyle#383
  / PyCQA/pycodestyle#384
* Identify binary operators as unary; PyCQA/pycodestyle#484 /
  PyCQA/pycodestyle#485

1.7.0 (2016-01-12)
------------------

Changes:

* Reverted the fix in PyCQA/pycodestyle#368, "options passed on command
  line are only ones accepted" feature. This has many unintended
  consequences in pep8 and flake8 and needs to be reworked when I have
  more time.
* Added support for Python 3.5. (Issue PyCQA/pycodestyle#420 &
  PyCQA/pycodestyle#459)
* Added support for multi-line config_file option parsing. (Issue
  PyCQA/pycodestyle#429)
* Improved parameter parsing. (Issues PyCQA/pycodestyle#420 &
  PyCQA/pycodestyle#456)

Bugs:

* Fixed BytesWarning on Python 3. (Issue PyCQA/pycodestyle#459)