### PR TITLE
QUA-183: update pep8/pycodestyle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /usr/src/app
 
 RUN adduser -u 9000 -D app
 
-RUN apk add --no-cache python3
+RUN apk add --no-cache python3 py3-pip
 
 COPY requirements.txt /usr/src/app
 RUN pip3 install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pycodestyle ~= 2.3.1
+pycodestyle ~= 2.8.0


### PR DESCRIPTION
This PR updates pep8/pycodestyle to the latest version `2.8.0`

Additionally, the `py3-pip` package has been added to fix an error during the building of the Docker image (pip3 not found).