### PR TITLE
QUA-468: update base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:3.15.5
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
This PR updates the base image in the Dockerfile from `alpine:edge` to `alpine:3.15.5`.